### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "php": ">=5.5.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "illuminate/console": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0|~7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0|~7.0"
+        "illuminate/console": "^5.0|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",


### PR DESCRIPTION
Include `^8.0` in version range so that the package can be installed with Laravel 8.
I have also simplified the version ranges.